### PR TITLE
Update plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,6 +3,8 @@ main: point3d.sortinghopper2.SortingHopper
 description: Bukkit plugin that creates item filter from a hopper
 version: 2.3
 api-version: 1.13
+softdepend:
+  - Multiverse-Core
 commands:
   sortinghopper:
     description: give | save [name] | load [name] | reload | importminecrafttags


### PR DESCRIPTION
Plugin will break in newer versions if plugin is loaded before Multiverse loads worlds due to the WeakReference to the world in locations.
Makes it work with 1.15 aswell